### PR TITLE
client: allow file as parameter for delete

### DIFF
--- a/hide/client/hide_client.py
+++ b/hide/client/hide_client.py
@@ -120,9 +120,17 @@ class HideClient:
             raise HideClientError(response.text)
         return model.File.model_validate(response.json())
 
-    def delete_file(self, project_id: str, path: str) -> bool:
+    def delete_file(
+        self, project_id: str, file: str | model.File | model.FileInfo
+    ) -> bool:
+        if isinstance(file, model.FileInfo):
+            file = file.path
+
+        if isinstance(file, model.File):
+            file = file.path
+
         response = requests.delete(
-            f"{self.base_url}/projects/{project_id}/files/{path}"
+            f"{self.base_url}/projects/{project_id}/files/{file}"
         )
         if not response.ok:
             raise HideClientError(response.text)

--- a/hide/client/hide_client.py
+++ b/hide/client/hide_client.py
@@ -121,7 +121,7 @@ class HideClient:
         return model.File.model_validate(response.json())
 
     def delete_file(
-        self, project_id: str, file: str | model.File | model.FileInfo
+        self, project_id: str, file: model.FilePath | model.File | model.FileInfo
     ) -> bool:
         if isinstance(file, model.FileInfo):
             file = file.path

--- a/hide/client/hide_client.py
+++ b/hide/client/hide_client.py
@@ -63,7 +63,9 @@ class HideClient:
             raise HideClientError(response.text)
         return model.TaskResult.model_validate(response.json())
 
-    def create_file(self, project_id: str, path: str, content: str) -> model.File:
+    def create_file(
+        self, project_id: str, path: model.FilePath, content: str
+    ) -> model.File:
         response = requests.post(
             f"{self.base_url}/projects/{project_id}/files",
             json={"path": path, "content": content},
@@ -75,7 +77,7 @@ class HideClient:
     def get_file(
         self,
         project_id: str,
-        path: str,
+        path: model.FilePath,
         start_line: Optional[int] = None,
         num_lines: Optional[int] = None,
     ) -> model.File:
@@ -90,7 +92,7 @@ class HideClient:
     def update_file(
         self,
         project_id: str,
-        path: str,
+        path: model.FilePath,
         update: Union[model.UdiffUpdate, model.LineDiffUpdate, model.OverwriteUpdate],
     ) -> model.File:
         match update:

--- a/hide/model.py
+++ b/hide/model.py
@@ -13,6 +13,7 @@ VerticalLine = "\u2502"
 HorizontalLine = "\u2500"
 HorizontalEllipsis = "\u2026"
 
+FilePath = str
 
 class Repository(BaseModel):
     url: str = Field(..., description="The URL of the repository.")
@@ -88,7 +89,7 @@ class Line(BaseModel):
 
 
 class File(BaseModel):
-    path: str = Field(..., description="The path of the file.")
+    path: FilePath = Field(..., description="The path of the file.")
     lines: list[Line] = Field(default_factory=list)
     diagnostics: List[Diagnostic] = Field(default_factory=list)
 
@@ -230,7 +231,7 @@ class Task(BaseModel):
 
 
 class FileInfo(BaseModel):
-    path: str = Field(..., description="The path of the file.")
+    path: FilePath = Field(..., description="The path of the file.")
 
 
 class FileUpdateType(str, Enum):

--- a/hide/toolkit/toolkit.py
+++ b/hide/toolkit/toolkit.py
@@ -113,7 +113,7 @@ class Toolkit:
     def delete_file(self, path: str) -> str:
         """Delete a file from the project."""
         try:
-            deleted = self.client.delete_file(project_id=self.project.id, path=path)
+            deleted = self.client.delete_file(project_id=self.project.id, file=path)
             return (
                 f"File deleted: {path}" if deleted else f"Failed to delete file: {path}"
             )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1382,13 +1382,13 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.3.2"
+version = "8.3.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.3.2-py3-none-any.whl", hash = "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5"},
-    {file = "pytest-8.3.2.tar.gz", hash = "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce"},
+    {file = "pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"},
+    {file = "pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181"},
 ]
 
 [package.dependencies]
@@ -1932,4 +1932,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "71f12256a0aef725a44995799bef8d0d21a54a0bea4402e43e1be7c735c6e5fd"
+content-hash = "a6615e0663ad27b1c4f554bff68b49f35d0d3cde8f1b3de891e4e9df0295314e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ pydantic = "^2.7.3"
 pyjson5 = "^1.6.6"
 
 [tool.poetry.group.test.dependencies]
-pytest = "^8.2.2"
+pytest = "^8.3.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_hide_client.py
+++ b/tests/test_hide_client.py
@@ -219,6 +219,24 @@ def test_delete_file_success(client):
         )
 
 
+def test_delete_file_with_file(client):
+    with patch("requests.delete") as mock_delete:
+        mock_delete.return_value = Mock(ok=True, status_code=204)
+        assert client.delete_file(PROJECT_ID, model.File(path=PATH))
+        mock_delete.assert_called_once_with(
+            f"http://localhost/projects/123/files/{PATH}"
+        )
+
+
+def test_delete_file_with_file_info(client):
+    with patch("requests.delete") as mock_delete:
+        mock_delete.return_value = Mock(ok=True, status_code=204)
+        assert client.delete_file(PROJECT_ID, model.FileInfo(path=PATH))
+        mock_delete.assert_called_once_with(
+            f"http://localhost/projects/123/files/{PATH}"
+        )
+
+
 def test_delete_file_failure(client):
     with patch("requests.delete") as mock_delete:
         mock_delete.return_value = Mock(ok=False, text="Error")


### PR DESCRIPTION
Part of the problem in #22 was that `delete_file` expected file as a string (i.e. path) instead of a `File`. This PR makes API more flexible allowing to pass `File` or `FileInfo` as an argument.