### PR TITLE
Add timeout to toolkit's `run_task`

### DIFF
--- a/hide/toolkit/toolkit.py
+++ b/hide/toolkit/toolkit.py
@@ -30,7 +30,7 @@ class Toolkit:
         """
         try:
             result = self.client.run_task(
-                project_id=self.project.id, command=command, alias=alias
+                project_id=self.project.id, command=command, alias=alias, timeout=timeout
             )
             return f"exit code: {result.exit_code}\nstdout: {result.stdout}\nstderr: {result.stderr}"
         except Exception as e:

--- a/tests/test_hide_client.py
+++ b/tests/test_hide_client.py
@@ -146,6 +146,11 @@ def test_run_task_command_and_alias(client):
         client.run_task(PROJECT_ID, command="echo Hello", alias="build")
 
 
+def test_run_task_negative_timeout(client):
+    with pytest.raises(HideClientError, match="Timeout must be a positive integer"):
+        client.run_task(PROJECT_ID, command="echo Hello", timeout=-1)
+
+
 def test_create_file_success(client):
     with patch("requests.post") as mock_post:
         mock_post.return_value = Mock(ok=True, json=lambda: FILE)


### PR DESCRIPTION
Forwards the timeout argument in `toolkit`'s `run_task` method to the underlying `client.run_task`.  
Fixes #29